### PR TITLE
Add Moon+ Reader to Android app list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,6 +248,7 @@ _Apps that support WebDAV in some form, e.g. for backup and sync_
 
 - [Joplin](https://play.google.com/store/apps/details?id=net.cozic.joplin) - Note taking and to-do application that supports WebDAV sync.
 - [Keepass2Android](https://play.google.com/store/apps/details?id=keepass2android.keepass2android) - KeePass-based password manager that supports WebDAV sync. [Sources](https://github.com/PhilippC/keepass2android). `GPL3`
+- [Moon+ Reader](https://www.moondownload.com) - Reading app that supports syncing books, reading position, notes, & highlights via WebDAV. `Proprietary`
 - [ntodotxt](https://github.com/tmaegel/ntodotxt) - TODO App with sync via WebDAV. `MIT`
 - [Orgzly](https://www.orgzly.com/) - Outliner for notes and to-do lists. [Source code](https://github.com/orgzly).
 - [pokatomnik/Davno](https://github.com/pokatomnik/Davno) - Web**DAV NO**tes, Android app, unfinished. `WIP`, `Kotlin`


### PR DESCRIPTION
Add Android ereader app Moon+ Reader - supports syncing books & other metadata with WebDAV.