### PR TITLE
Add BeeCount to Mobile apps > Other apps (Android + iOS)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,7 @@ _General purpose apps to browse and manage files on a WebDAV server_
 
 _Apps that support WebDAV in some form, e.g. for backup and sync_
 
+- [BeeCount](https://github.com/TNT-Likely/BeeCount) – Privacy-first expense tracker with multi-backend cloud sync including WebDAV. `Source-Available` `Dart`
 - [Joplin](https://play.google.com/store/apps/details?id=net.cozic.joplin) - Note taking and to-do application that supports WebDAV sync.
 - [Keepass2Android](https://play.google.com/store/apps/details?id=keepass2android.keepass2android) - KeePass-based password manager that supports WebDAV sync. [Sources](https://github.com/PhilippC/keepass2android). `GPL3`
 - [Moon+ Reader](https://www.moondownload.com) - Reading app that supports syncing books, reading position, notes, & highlights via WebDAV. `Proprietary`
@@ -276,6 +277,7 @@ _General purpose apps to browse and manage files on a WebDAV server_
 _Apps that support WebDAV in some form, e.g. for backup and sync_
 
 - [1Writer](https://apps.apple.com/app/1writer-markdown-text-editor/id680469088) - Markdown text editor that supports importing from WebDAV.
+- [BeeCount](https://apps.apple.com/app/id6754611670) – Privacy-first expense tracker with multi-backend cloud sync including WebDAV. [Source](https://github.com/TNT-Likely/BeeCount). `Source-Available` `Dart`
 - [beorg](https://apps.apple.com/app/beorg-to-do-list-agenda/id1238649962) - TO-DO list and agenda app with WebDAV sync support.
 - [GoodReader](https://apps.apple.com/app/goodreader-pdf-editor-viewer/id777310222) - PDF viewer and editor that supports WebDAV sync.
 - [Joplin](https://apps.apple.com/app/joplin/id1315599797) - Note taking and to-do application that supports WebDAV sync.


### PR DESCRIPTION
## Summary

Adds **BeeCount** to both `Mobile apps > Android > Other apps` and `Mobile apps > iOS > Other apps`.

BeeCount is a privacy-first cross-platform personal expense tracker (Android · iOS · Web) built with Flutter, with multi-backend cloud sync — **including WebDAV** alongside iCloud, Supabase, S3, and its own self-hostable BeeCount Cloud. WebDAV is a first-class sync option, not an afterthought.

- Source: https://github.com/TNT-Likely/BeeCount (~1.5k★, 200+ forks, active)
- App Store: https://apps.apple.com/app/id6754611670
- Google Play: https://play.google.com/store/apps/details?id=com.tntlikely.beecount
- WebDAV sync implementation: [packages/flutter_cloud_sync_webdav](https://github.com/TNT-Likely/BeeCount/tree/main/packages/flutter_cloud_sync_webdav)

## Compliance with CONTRIBUTING.md

- [x] Searched previous suggestions (no existing BeeCount entry)
- [x] Individual PR for this single suggestion
- [x] Title is descriptive
- [x] Entries placed alphabetically in `Other apps` sub-sections of both Android and iOS (similar to how Table Habit appears in both)

## Affiliation

I am the author and primary maintainer of BeeCount (@TNT-Likely).

## License note (transparency)

BeeCount uses a custom commercial source-available license (free for personal/non-commercial use; commercial use requires a paid license). I tagged it as `Source-Available` rather than a standard SPDX since there's no perfect match. Happy to relabel if you prefer a different convention.